### PR TITLE
v2.0

### DIFF
--- a/cmd/drsz/main.go
+++ b/cmd/drsz/main.go
@@ -24,7 +24,14 @@ func cli() Config {
 
 	csvArg := flag.String("o", "none", "save output to the provided CSV filepath")
 	concArg := flag.Int("c", 0, "number of concurrent directory size searches")
+	verArg := flag.Bool("v", false, "program version")
 	flag.Parse()
+
+	if *verArg {
+		fmt.Printf("drsz %s\n", drsz.Version)
+		os.Exit(0)
+	}
+
 	rootArg := flag.Arg(0)
 
 	// validate root arg

--- a/constant.go
+++ b/constant.go
@@ -1,0 +1,3 @@
+package drsz
+
+const Version = "v2.0"

--- a/drsz.go
+++ b/drsz.go
@@ -190,11 +190,6 @@ func (r *RootDir) CalcStats(concLimit uint8) error {
 
 	wg.Wait() // wait for goroutines to finish
 
-	if len(errors) != 0 {
-		// errors encountered, just return first one for simplicity for now
-		return fmt.Errorf("encountered %d errors, the first being: %v", len(errors), errors[0])
-	}
-
 	// print results using tabwriter
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', 0)
 	// add blank row
@@ -205,6 +200,16 @@ func (r *RootDir) CalcStats(concLimit uint8) error {
 	for _, d := range r.TopDirs {
 		fmt.Fprintf(tw, "%s\t%s\t%s\n", d.Name(), d.SizeString(), d.LastModified.Local().String())
 	}
+
+	// print errors and their associated directories
+	if len(errors) != 0 {
+		fmt.Fprintln(tw, "")
+		fmt.Fprintln(tw, "***WARN*** Processing failed on the following directories ***WARN***")
+		for i, err := range errors {
+			fmt.Fprintf(tw, "%d: %v\n", i+1, err)
+		}
+	}
+
 	tw.Flush()
 
 	return nil


### PR DESCRIPTION
Print a warning instead of exiting the program if errors are encountered walking through directories. This is usually permissions related and the better behavior for the intent of the program.